### PR TITLE
Remove extra layer of double quotes in string fields

### DIFF
--- a/src/main/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplate.java
+++ b/src/main/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplate.java
@@ -81,18 +81,18 @@ public class EiffelSourceChangeCreatedEventTemplate extends EventTemplate {
     public void setEventMeta(JsonObject meta) {
         JsonObject change = meta.getAsJsonObject("change");
         JsonObject uploader = meta.getAsJsonObject("uploader");
-        source.setHost(change.get("url").toString());
-        source.setName(uploader.get("name").toString());
+        source.setHost(change.get("url").getAsString());
+        source.setName(uploader.get("name").getAsString());
         eventMeta.setSource(source);
     }
 
     @Override
     public void setEventData(JsonObject data) {
         JsonObject change = data.getAsJsonObject("change");
-        gitIdentifier.setCommitId(change.get("id").toString());
-        gitIdentifier.setBranch(change.get("branch").toString());
-        gitIdentifier.setRepoName(data.get("project").toString());
-        gitIdentifier.setRepoUri(change.get("url").toString());
+        gitIdentifier.setCommitId(change.get("id").getAsString());
+        gitIdentifier.setBranch(change.get("branch").getAsString());
+        gitIdentifier.setRepoName(data.get("project").getAsString());
+        gitIdentifier.setRepoUri(change.get("url").getAsString());
 
         eventData.setGitIdentifier(gitIdentifier);
     }

--- a/src/main/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplate.java
+++ b/src/main/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplate.java
@@ -90,18 +90,18 @@ public class EiffelSourceChangeSubmittedEventTemplate extends EventTemplate {
         JsonObject change = meta.getAsJsonObject("change");
         JsonObject patchSet = meta.getAsJsonObject("patchSet");
         JsonObject uploader = patchSet.getAsJsonObject("uploader");
-        source.setHost(change.get("url").toString());
-        source.setName(uploader.get("name").toString());
+        source.setHost(change.get("url").getAsString());
+        source.setName(uploader.get("name").getAsString());
         eventMeta.setSource(source);
     }
 
     @Override
     public void setEventData(JsonObject data) {
         JsonObject change = data.getAsJsonObject("change");
-        gitIdentifier.setCommitId(change.get("id").toString());
-        gitIdentifier.setBranch(change.get("branch").toString());
-        gitIdentifier.setRepoName(data.get("project").toString());
-        gitIdentifier.setRepoUri(change.get("url").toString());
+        gitIdentifier.setCommitId(change.get("id").getAsString());
+        gitIdentifier.setBranch(change.get("branch").getAsString());
+        gitIdentifier.setRepoName(data.get("project").getAsString());
+        gitIdentifier.setRepoUri(change.get("url").getAsString());
 
         eventData.setGitIdentifier(gitIdentifier);
     }

--- a/src/main/java/com/axis/eiffel/gerrit/lib/formatter/EiffelEventService.java
+++ b/src/main/java/com/axis/eiffel/gerrit/lib/formatter/EiffelEventService.java
@@ -121,7 +121,7 @@ public class EiffelEventService {
 
     private String getGerritType(JsonObject gerritEvent) throws EventException {
         if (gerritEvent.get("type") == null) throw new EventException("Event type is missing.");
-        return gerritEvent.get("type").toString().replace("\"", "");
+        return gerritEvent.get("type").getAsString();
     }
 
     /**

--- a/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplateTest.java
+++ b/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplateTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.axis.eiffel.gerrit.lib.events;
+
+import com.ericsson.eiffel.remrem.semantics.SemanticsService;
+import com.ericsson.eiffel.semantics.events.GitIdentifier;
+import com.ericsson.eiffel.semantics.events.Source;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.axis.eiffel.gerrit.lib.formatter.TestResourceType.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Magnus Bäck, magnus.back@axis.com
+ */
+@DisplayName("Testing EiffelSourceChangeCreatedEventTemplate")
+public class EiffelSourceChangeCreatedEventTemplateTest {
+
+    private final SemanticsService semanticsService = new SemanticsService();
+
+    @Test
+    @DisplayName("Testing the contents of the resulting event data")
+    void TestData() {
+        EiffelSourceChangeCreatedEventTemplate template = new EiffelSourceChangeCreatedEventTemplate(semanticsService);
+        template.generateTemplate(GERRIT_CREATED_EVENT.load());
+
+        GitIdentifier gitIdentifier = template.getEvent().getData().getGitIdentifier();
+        assertEquals("\"master\"", gitIdentifier.getBranch());
+        assertEquals("\"Icf5666b32dc733440666910faa612b998e44ced6\"", gitIdentifier.getCommitId());
+        assertEquals("\"apps/utils/test\"", gitIdentifier.getRepoName());
+        assertEquals("\"https://this.is.a.url\"", gitIdentifier.getRepoUri());
+    }
+
+    @Test
+    @DisplayName("Testing the contents of the resulting event metadata")
+    void TestMeta() {
+        EiffelSourceChangeCreatedEventTemplate template = new EiffelSourceChangeCreatedEventTemplate(semanticsService);
+        template.generateTemplate(GERRIT_CREATED_EVENT.load());
+
+        Source source = template.getEvent().getMeta().getSource();
+        assertEquals("", source.getDomainId());
+        assertEquals("\"https://this.is.a.url\"", source.getHost());
+        assertEquals("\"Test Testsson\"", source.getName());
+        assertEquals("", source.getUri());
+    }
+}

--- a/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplateTest.java
+++ b/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeCreatedEventTemplateTest.java
@@ -39,10 +39,10 @@ public class EiffelSourceChangeCreatedEventTemplateTest {
         template.generateTemplate(GERRIT_CREATED_EVENT.load());
 
         GitIdentifier gitIdentifier = template.getEvent().getData().getGitIdentifier();
-        assertEquals("\"master\"", gitIdentifier.getBranch());
-        assertEquals("\"Icf5666b32dc733440666910faa612b998e44ced6\"", gitIdentifier.getCommitId());
-        assertEquals("\"apps/utils/test\"", gitIdentifier.getRepoName());
-        assertEquals("\"https://this.is.a.url\"", gitIdentifier.getRepoUri());
+        assertEquals("master", gitIdentifier.getBranch());
+        assertEquals("Icf5666b32dc733440666910faa612b998e44ced6", gitIdentifier.getCommitId());
+        assertEquals("apps/utils/test", gitIdentifier.getRepoName());
+        assertEquals("https://this.is.a.url", gitIdentifier.getRepoUri());
     }
 
     @Test
@@ -53,8 +53,8 @@ public class EiffelSourceChangeCreatedEventTemplateTest {
 
         Source source = template.getEvent().getMeta().getSource();
         assertEquals("", source.getDomainId());
-        assertEquals("\"https://this.is.a.url\"", source.getHost());
-        assertEquals("\"Test Testsson\"", source.getName());
+        assertEquals("https://this.is.a.url", source.getHost());
+        assertEquals("Test Testsson", source.getName());
         assertEquals("", source.getUri());
     }
 }

--- a/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplateTest.java
+++ b/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplateTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.axis.eiffel.gerrit.lib.events;
+
+import com.ericsson.eiffel.remrem.semantics.SemanticsService;
+import com.ericsson.eiffel.semantics.events.GitIdentifier;
+import com.ericsson.eiffel.semantics.events.Source;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.axis.eiffel.gerrit.lib.formatter.TestResourceType.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Magnus Bäck, magnus.back@axis.com
+ */
+@DisplayName("Testing EiffelSourceChangeSubmittedEventTemplate")
+public class EiffelSourceChangeSubmittedEventTemplateTest {
+
+    private final SemanticsService semanticsService = new SemanticsService();
+
+    @Test
+    @DisplayName("Testing the contents of the resulting event data")
+    void TestData() {
+        EiffelSourceChangeSubmittedEventTemplate template = new EiffelSourceChangeSubmittedEventTemplate(semanticsService);
+        template.generateTemplate(GERRIT_MERGED_EVENT.load());
+
+        GitIdentifier gitIdentifier = template.getEvent().getData().getGitIdentifier();
+        assertEquals("\"master\"", gitIdentifier.getBranch());
+        assertEquals("\"Ic9752f5819304951194dcbc48baead626b409211\"", gitIdentifier.getCommitId());
+        assertEquals("\"layers/meta-test\"", gitIdentifier.getRepoName());
+        assertEquals("\"https://this.is.a.url\"", gitIdentifier.getRepoUri());
+    }
+
+    @Test
+    @DisplayName("Testing the contents of the resulting event metadata")
+    void TestMeta() {
+        EiffelSourceChangeSubmittedEventTemplate template = new EiffelSourceChangeSubmittedEventTemplate(semanticsService);
+        template.generateTemplate(GERRIT_CREATED_EVENT.load());
+
+        Source source = template.getEvent().getMeta().getSource();
+        assertEquals("", source.getDomainId());
+        assertEquals("\"https://this.is.a.url\"", source.getHost());
+        assertEquals("\"Test Testsson\"", source.getName());
+        assertEquals("", source.getUri());
+    }
+}

--- a/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplateTest.java
+++ b/src/test/java/com/axis/eiffel/gerrit/lib/events/EiffelSourceChangeSubmittedEventTemplateTest.java
@@ -39,10 +39,10 @@ public class EiffelSourceChangeSubmittedEventTemplateTest {
         template.generateTemplate(GERRIT_MERGED_EVENT.load());
 
         GitIdentifier gitIdentifier = template.getEvent().getData().getGitIdentifier();
-        assertEquals("\"master\"", gitIdentifier.getBranch());
-        assertEquals("\"Ic9752f5819304951194dcbc48baead626b409211\"", gitIdentifier.getCommitId());
-        assertEquals("\"layers/meta-test\"", gitIdentifier.getRepoName());
-        assertEquals("\"https://this.is.a.url\"", gitIdentifier.getRepoUri());
+        assertEquals("master", gitIdentifier.getBranch());
+        assertEquals("Ic9752f5819304951194dcbc48baead626b409211", gitIdentifier.getCommitId());
+        assertEquals("layers/meta-test", gitIdentifier.getRepoName());
+        assertEquals("https://this.is.a.url", gitIdentifier.getRepoUri());
     }
 
     @Test
@@ -53,8 +53,8 @@ public class EiffelSourceChangeSubmittedEventTemplateTest {
 
         Source source = template.getEvent().getMeta().getSource();
         assertEquals("", source.getDomainId());
-        assertEquals("\"https://this.is.a.url\"", source.getHost());
-        assertEquals("\"Test Testsson\"", source.getName());
+        assertEquals("https://this.is.a.url", source.getHost());
+        assertEquals("Test Testsson", source.getName());
         assertEquals("", source.getUri());
     }
 }

--- a/src/test/java/com/axis/eiffel/gerrit/lib/formatter/EiffelEventServiceTest.java
+++ b/src/test/java/com/axis/eiffel/gerrit/lib/formatter/EiffelEventServiceTest.java
@@ -68,8 +68,8 @@ public class EiffelEventServiceTest {
         assertNotNull(eiffelCreate);
         assertNotNull(eiffelSubmit);
 
-        assertEquals(eiffelCreate.getAsJsonObject("meta").get("id").toString(),
-                eiffelSubmit.getAsJsonArray("links").get(0).getAsJsonObject().get("target").toString());
+        assertEquals(eiffelCreate.getAsJsonObject("meta").get("id").getAsString(),
+                eiffelSubmit.getAsJsonArray("links").get(0).getAsJsonObject().get("target").getAsString());
     }
 
     @Test

--- a/src/test/resources/testdata/eiffelCreatedEvent.json
+++ b/src/test/resources/testdata/eiffelCreatedEvent.json
@@ -15,10 +15,10 @@
   },
   "data": {
     "gitIdentifier": {
-      "commitId": "\"I4a75a2005033860f084463c15e7ce40312e53c40\"",
+      "commitId": "\"Icf5666b32dc733440666910faa612b998e44ced6\"",
       "branch": "\"master\"",
-      "repoName": "\"test\"",
-      "repoUri": "\"https://link.se\""
+      "repoName": "\"apps/utils/test\"",
+      "repoUri": "\"https://this.is.a.url\""
     },
     "customData": [
     ]

--- a/src/test/resources/testdata/eiffelCreatedEvent.json
+++ b/src/test/resources/testdata/eiffelCreatedEvent.json
@@ -8,17 +8,17 @@
     ],
     "source": {
       "domainId": "",
-      "host": "\"https://link.se\"",
-      "name": "\"Test Testsson\"",
+      "host": "https://link.se",
+      "name": "Test Testsson",
       "uri": ""
     }
   },
   "data": {
     "gitIdentifier": {
-      "commitId": "\"Icf5666b32dc733440666910faa612b998e44ced6\"",
-      "branch": "\"master\"",
-      "repoName": "\"apps/utils/test\"",
-      "repoUri": "\"https://this.is.a.url\""
+      "commitId": "Icf5666b32dc733440666910faa612b998e44ced6",
+      "branch": "master",
+      "repoName": "apps/utils/test",
+      "repoUri": "https://this.is.a.url"
     },
     "customData": [
     ]

--- a/src/test/resources/testdata/eiffelSubmittedEvent.json
+++ b/src/test/resources/testdata/eiffelSubmittedEvent.json
@@ -8,17 +8,17 @@
     ],
     "source": {
       "domainId": "",
-      "host": "\"https://this.is.a.url\"",
-      "name": "\"Test Testsson\"",
+      "host": "https://this.is.a.url",
+      "name": "Test Testsson",
       "uri": ""
     }
   },
   "data": {
     "gitIdentifier": {
-      "commitId": "\"Ic9752f5819304951194dcbc48baead626b409211\"",
-      "branch": "\"master\"",
-      "repoName": "\"layers/meta-test\"",
-      "repoUri": "\"https://this.is.a.url\""
+      "commitId": "Ic9752f5819304951194dcbc48baead626b409211",
+      "branch": "master",
+      "repoName": "layers/meta-test",
+      "repoUri": "https://this.is.a.url"
     },
     "customData": [
     ]

--- a/src/test/resources/testdata/eiffelSubmittedEvent.json
+++ b/src/test/resources/testdata/eiffelSubmittedEvent.json
@@ -8,17 +8,17 @@
     ],
     "source": {
       "domainId": "",
-      "host": "\"https://links.se\"",
+      "host": "\"https://this.is.a.url\"",
       "name": "\"Test Testsson\"",
       "uri": ""
     }
   },
   "data": {
     "gitIdentifier": {
-      "commitId": "\"I0b165d8ad7bfdca846e91ae16913df5bbe7e153c\"",
+      "commitId": "\"Ic9752f5819304951194dcbc48baead626b409211\"",
       "branch": "\"master\"",
-      "repoName": "\"test\"",
-      "repoUri": "\"https://link.se\""
+      "repoName": "\"layers/meta-test\"",
+      "repoUri": "\"https://this.is.a.url\""
     },
     "customData": [
     ]


### PR DESCRIPTION
### Applicable Issues
Fixes #3 

### Description of the Change
The values of various event fields had an extra layer of double quotes,

```
...
"repoName": "\"some/git\"",
...
```

which obviously isn't correct. This was because toString() was called on the JSON elements. Changing to getAsString() instead. Added new testcases to cover this.

### Alternate Designs
None; this is trivial bugfix.

### Benefits
Events produced by the library will be more correct.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
